### PR TITLE
Emit `Debugger.enable` event on the server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -126,6 +126,11 @@ class InspectorConnection {
 
   _ondata(data) {
     const { id, method, params } = JSON.parse(data)
+    if(method === 'Debugger.enable') {
+      // The sources panel of devtools frontend will only include scripts that were compiled after the Debugger.enable command has been sent by the inspector frontend.
+      // Bare runtime can wait for this event to learn that frontend is ready for debugging.
+      this._server.emit(method)
+    }
 
     this._session.post(method, params, (err, result) => {
       const response = err ? { id, error: err } : { id, result }


### PR DESCRIPTION
The sources panel of devtools frontend will only include scripts that were compiled after the `Debugger.enable` command has been sent by the inspector frontend.
Bare runtime can wait for `Debugger.enable` event to learn that frontend is ready for user debugging.